### PR TITLE
Fix/persist new record before async queue

### DIFF
--- a/src/Extension/AsyncCMSMain.php
+++ b/src/Extension/AsyncCMSMain.php
@@ -57,7 +57,8 @@ class AsyncCMSMain extends Extension
         // New records have no DB row yet. Write a minimal row now so the job
         // can look up the record by a real ID when it runs later.
         if ($record->ID === 0) {
-            $record->write();
+            // writeWithoutVersion avoids creating a version stub with no form data.
+            $record->writeWithoutVersion();
             $data['ID'] = $record->ID;
 
             // Update the URL params so asyncStoreState() records the real ID,
@@ -158,7 +159,8 @@ class AsyncCMSMain extends Extension
     public function asyncStoreState(): array
     {
         return [
-            'URLParams' => $this->owner->getURLParams(),
+            'URLParams'  => $this->owner->getURLParams(),
+            'RequestURL' => $this->owner->getRequest()->getURL(true),
         ];
     }
 

--- a/src/Extension/AsyncCMSMain.php
+++ b/src/Extension/AsyncCMSMain.php
@@ -54,6 +54,19 @@ class AsyncCMSMain extends Extension
             return $record;
         }
 
+        // New records have no DB row yet. Write a minimal row now so the job
+        // can look up the record by a real ID when it runs later.
+        if ($record->ID === 0) {
+            $record->write();
+            $data['ID'] = $record->ID;
+
+            // Update the URL params so asyncStoreState() records the real ID,
+            // not the temporary "new-xxx" placeholder.
+            $urlParams = $this->owner->getURLParams();
+            $urlParams['ID'] = (string) $record->ID;
+            $this->owner->setURLParams($urlParams);
+        }
+
         $injector = Injector::inst();
         $job = $injector->create(
             AsyncSave::class,
@@ -94,6 +107,7 @@ class AsyncCMSMain extends Extension
     public function asyncGetRecordAndAssertPermissions(array $data)
     {
         $className = $this->owner->config()->get('tree_class');
+
         if (!$className) {
             $className = $this->owner->config()->get('model_class');
         }

--- a/src/Job/AsyncPublish.php
+++ b/src/Job/AsyncPublish.php
@@ -3,7 +3,7 @@
 namespace AndrewAndante\SilverStripe\AsyncPublisher\Job;
 
 use AndrewAndante\SilverStripe\AsyncPublisher\Extension\AsyncPublisherExtension;
-use SilverStripe\Control\Controller;
+use SilverStripe\CMS\Controllers\CMSMain;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\Session;
 use SilverStripe\Core\ClassInfo;
@@ -77,16 +77,16 @@ class AsyncPublish extends AbstractQueuedJob implements QueuedJob
     {
         // Restore the member who queued the job so permission checks pass.
         if ($this->memberID) {
-            $member = DataObject::get(Member::class)->byID($this->memberID);
+            $member = DataObject::get_by_id(Member::class, $this->memberID);
             if ($member) {
                 Security::setCurrentUser($member);
             }
         }
 
-        // Create a real request with session and push a controller so
+        // Create a real request with session and push a CMS controller so
         // CMS extensions that call Controller::curr() work during publish.
-        $controller = Injector::inst()->create(Controller::class);
-        $request = new HTTPRequest('GET', '/');
+        $controller = Injector::inst()->create(CMSMain::class);
+        $request = new HTTPRequest('GET', '/admin/pages/');
         $request->setSession(new Session([]));
         $controller->setRequest($request);
         $controller->pushCurrent();

--- a/src/Job/AsyncPublish.php
+++ b/src/Job/AsyncPublish.php
@@ -3,9 +3,16 @@
 namespace AndrewAndante\SilverStripe\AsyncPublisher\Job;
 
 use AndrewAndante\SilverStripe\AsyncPublisher\Extension\AsyncPublisherExtension;
+use SilverStripe\Control\Controller;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\NullHTTPRequest;
+use SilverStripe\Control\Session;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\Security\Member;
+use SilverStripe\Security\Security;
 use SilverStripe\Versioned\Versioned;
 use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
 use Symbiote\QueuedJobs\Services\QueuedJob;
@@ -24,6 +31,13 @@ class AsyncPublish extends AbstractQueuedJob implements QueuedJob
             $this->objectClass = ClassInfo::class_name($object);
             $this->objectTitle = $object->Title ?? 'unknown';
             $this->signature = $object->generateSignature();
+
+            // Store the member who queued the job so permission checks pass
+            // when the job runs in a context with no logged-in user.
+            $member = Security::getCurrentUser();
+            if ($member) {
+                $this->memberID = $member->ID;
+            }
         }
 
         $this->toStage = $toStage ?? Versioned::LIVE;
@@ -62,22 +76,42 @@ class AsyncPublish extends AbstractQueuedJob implements QueuedJob
      */
     public function process()
     {
-        $object = DataObject::get($this->objectClass)->byID($this->objectID);
-
-        if (!$object || !$object->exists()) {
-            $this->addMessage('Could not find object');
-        } elseif (!$object->hasExtension(AsyncPublisherExtension::class)) {
-            $this->addMessage('Object does not have AsyncPublisherExtension applied');
-        } else {
-            $object->doPublishRecursive();
-            $this->addMessage(_t(
-                self::class . '.PUBLISHED',
-                "Published '{title}' from queue successfully.",
-                ['title' => $object->Title]
-            ));
+        // Restore the member who queued the job so permission checks pass.
+        if ($this->memberID) {
+            $member = DataObject::get(Member::class)->byID($this->memberID);
+            if ($member) {
+                Security::setCurrentUser($member);
+            }
         }
 
-        $this->isComplete = true;
+        // Create a real request with session and push a controller so
+        // CMS extensions that call Controller::curr() work during publish.
+        $controller = Injector::inst()->create(Controller::class);
+        $request = new HTTPRequest('GET', '/');
+        $request->setSession(new Session([]));
+        $controller->setRequest($request);
+        $controller->pushCurrent();
+
+        try {
+            $object = DataObject::get($this->objectClass)->byID($this->objectID);
+
+            if (!$object || !$object->exists()) {
+                $this->addMessage('Could not find object');
+            } elseif (!$object->hasExtension(AsyncPublisherExtension::class)) {
+                $this->addMessage('Object does not have AsyncPublisherExtension applied');
+            } else {
+                $object->doPublishRecursive();
+                $this->addMessage(_t(
+                    self::class . '.PUBLISHED',
+                    "Published '{title}' from queue successfully.",
+                    ['title' => $object->Title]
+                ));
+            }
+
+            $this->isComplete = true;
+        } finally {
+            $controller->popCurrent();
+        }
     }
 
 }

--- a/src/Job/AsyncPublish.php
+++ b/src/Job/AsyncPublish.php
@@ -5,7 +5,6 @@ namespace AndrewAndante\SilverStripe\AsyncPublisher\Job;
 use AndrewAndante\SilverStripe\AsyncPublisher\Extension\AsyncPublisherExtension;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
-use SilverStripe\Control\NullHTTPRequest;
 use SilverStripe\Control\Session;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Injector\Injectable;

--- a/src/Job/AsyncSave.php
+++ b/src/Job/AsyncSave.php
@@ -3,6 +3,7 @@
 namespace AndrewAndante\SilverStripe\AsyncPublisher\Job;
 
 use SilverStripe\Control\Controller;
+use SilverStripe\Control\Session;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Security\Member;
@@ -92,6 +93,10 @@ class AsyncSave extends AbstractQueuedJob
         if ($controller->hasMethod('asyncRestoreState')) {
             $controller->asyncRestoreState($this->controllerState);
         }
+
+        // Set up an empty session on the request so CMS code that calls
+        // getRequest()->getSession() does not throw during job processing.
+        $controller->getRequest()->setSession(new Session([]));
 
         // Push the controller onto the stack so Controller::curr() returns a valid
         // controller for CMS extensions that expect an active HTTP context (e.g.

--- a/src/Job/AsyncSave.php
+++ b/src/Job/AsyncSave.php
@@ -4,6 +4,9 @@ namespace AndrewAndante\SilverStripe\AsyncPublisher\Job;
 
 use SilverStripe\Control\Controller;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Security\Member;
+use SilverStripe\Security\Security;
 use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
 
 class AsyncSave extends AbstractQueuedJob
@@ -37,6 +40,13 @@ class AsyncSave extends AbstractQueuedJob
             if ($controller->hasMethod('asyncStoreState')) {
                 $this->controllerState = $controller->asyncStoreState();
             }
+
+            // Store the member who queued the job so permission checks pass
+            // when the job runs in a context with no logged-in user.
+            $member = Security::getCurrentUser();
+            if ($member) {
+                $this->memberID = $member->ID;
+            }
         }
 
         $this->formName = $formName;
@@ -68,6 +78,15 @@ class AsyncSave extends AbstractQueuedJob
 
     public function process(): void
     {
+        // Restore the member who queued the job so that CMS permission checks
+        // (e.g. canView() on a draft-only record) pass during job processing.
+        if ($this->memberID) {
+            $member = DataObject::get(Member::class)->byID($this->memberID);
+            if ($member) {
+                Security::setCurrentUser($member);
+            }
+        }
+
         $controller = Injector::inst()->create($this->controllerClass);
 
         if ($controller->hasMethod('asyncRestoreState')) {

--- a/src/Job/AsyncSave.php
+++ b/src/Job/AsyncSave.php
@@ -3,6 +3,7 @@
 namespace AndrewAndante\SilverStripe\AsyncPublisher\Job;
 
 use SilverStripe\Control\Controller;
+use SilverStripe\Control\Director;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Security\Member;
@@ -93,53 +94,62 @@ class AsyncSave extends AbstractQueuedJob
             $controller->asyncRestoreState($this->controllerState);
         }
 
-        $form = $controller->{$this->formName}();
-        $form->loadDataFrom($this->submission);
+        // Push the controller onto the stack so Controller::curr() returns a valid
+        // controller for CMS extensions that expect an active HTTP context (e.g.
+        // WorkflowEmbargoExpiryExtension calls Controller::curr() when building fields).
+        Controller::pushCurrent($controller);
 
-        $record = $controller->asyncGetRecordAndAssertPermissions($this->submission);
+        try {
+            $form = $controller->{$this->formName}();
+            $form->loadDataFrom($this->submission);
 
-        // START code copied from CMSMain::save
+            $record = $controller->asyncGetRecordAndAssertPermissions($this->submission);
 
-        // TODO Coupling to SiteTree
-        $record->HasBrokenLink = 0;
-        $record->HasBrokenFile = 0;
+            // START code copied from CMSMain::save
 
-        if (!$record->ObsoleteClassName) {
-            $record->writeWithoutVersion();
+            // TODO Coupling to SiteTree
+            $record->HasBrokenLink = 0;
+            $record->HasBrokenFile = 0;
+
+            if (!$record->ObsoleteClassName) {
+                $record->writeWithoutVersion();
+            }
+
+            // Update the class instance if necessary
+            if (isset($data['ClassName']) && $data['ClassName'] !== $record->ClassName) {
+                // Replace $record with a new instance of the new class
+                $newClassName = $data['ClassName'];
+                $record = $record->newClassInstance($newClassName);
+            }
+
+            // save form data into record
+            $form->saveInto($record);
+            $record->write();
+
+            // END code copied from CMSMain::save
+
+            // Errors will have been thrown before we reach this point; assume success if we're here (like CMSMain::save)
+            if ($this->andPublish) {
+                // publish immediately - no point in queuing a second job when we're already executing asynchronously
+                $record->doPublishRecursive();
+                $message = _t(
+                    self::class . '.PUBLISHED',
+                    "Saved and published '{title}' from queue successfully.",
+                    ['title' => $record->Title]
+                );
+            } else {
+                $message = _t(
+                    self::class . '.SAVED',
+                    "Saved '{title}' from queue successfully.",
+                    ['title' => $record->Title]
+                );
+            }
+
+            $this->addMessage($message);
+            $this->isComplete = true;
+        } finally {
+            Controller::popCurrent();
         }
-
-        // Update the class instance if necessary
-        if (isset($data['ClassName']) && $data['ClassName'] !== $record->ClassName) {
-            // Replace $record with a new instance of the new class
-            $newClassName = $data['ClassName'];
-            $record = $record->newClassInstance($newClassName);
-        }
-
-        // save form data into record
-        $form->saveInto($record);
-        $record->write();
-
-        // END code copied from CMSMain::save
-
-        // Errors will have been thrown before we reach this point; assume success if we're here (like CMSMain::save)
-        if ($this->andPublish) {
-            // publish immediately - no point in queuing a second job when we're already executing asynchronously
-            $record->doPublishRecursive();
-            $message = _t(
-                self::class . '.PUBLISHED',
-                "Saved and published '{title}' from queue successfully.",
-                ['title' => $record->Title]
-            );
-        } else {
-            $message = _t(
-                self::class . '.SAVED',
-                "Saved '{title}' from queue successfully.",
-                ['title' => $record->Title]
-            );
-        }
-
-        $this->addMessage($message);
-        $this->isComplete = true;
     }
 
 }

--- a/src/Job/AsyncSave.php
+++ b/src/Job/AsyncSave.php
@@ -83,7 +83,7 @@ class AsyncSave extends AbstractQueuedJob
         // Restore the member who queued the job so that CMS permission checks
         // (e.g. canView() on a draft-only record) pass during job processing.
         if ($this->memberID) {
-            $member = DataObject::get(Member::class)->byID($this->memberID);
+            $member = DataObject::get_by_id(Member::class, $this->memberID);
             if ($member) {
                 Security::setCurrentUser($member);
             }
@@ -98,8 +98,8 @@ class AsyncSave extends AbstractQueuedJob
         // Create a real HTTPRequest with a session so Form::getRequest() and
         // Controller::curr()->getRequest()->getSession() work during job processing.
         $urlParams = $this->controllerState['URLParams'] ?? [];
-        $recordID = $urlParams['ID'] ?? ($this->submission['ID'] ?? 0);
-        $request = new HTTPRequest('GET', '/admin/pages/edit/EditForm/' . $recordID);
+        $requestURL = $this->controllerState['RequestURL'] ?? '/';
+        $request = new HTTPRequest('GET', $requestURL);
         $request->setSession(new Session([]));
         $request->setRouteParams($urlParams);
         $controller->setRequest($request);
@@ -126,9 +126,9 @@ class AsyncSave extends AbstractQueuedJob
             }
 
             // Update the class instance if necessary
-            if (isset($data['ClassName']) && $data['ClassName'] !== $record->ClassName) {
+            if (isset($this->submission['ClassName']) && $this->submission['ClassName'] !== $record->ClassName) {
                 // Replace $record with a new instance of the new class
-                $newClassName = $data['ClassName'];
+                $newClassName = $this->submission['ClassName'];
                 $record = $record->newClassInstance($newClassName);
             }
 

--- a/src/Job/AsyncSave.php
+++ b/src/Job/AsyncSave.php
@@ -3,7 +3,6 @@
 namespace AndrewAndante\SilverStripe\AsyncPublisher\Job;
 
 use SilverStripe\Control\Controller;
-use SilverStripe\Control\Director;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Security\Member;
@@ -97,7 +96,7 @@ class AsyncSave extends AbstractQueuedJob
         // Push the controller onto the stack so Controller::curr() returns a valid
         // controller for CMS extensions that expect an active HTTP context (e.g.
         // WorkflowEmbargoExpiryExtension calls Controller::curr() when building fields).
-        Controller::pushCurrent($controller);
+        $controller->pushCurrent();
 
         try {
             $form = $controller->{$this->formName}();
@@ -148,7 +147,7 @@ class AsyncSave extends AbstractQueuedJob
             $this->addMessage($message);
             $this->isComplete = true;
         } finally {
-            Controller::popCurrent();
+            $controller->popCurrent();
         }
     }
 

--- a/src/Job/AsyncSave.php
+++ b/src/Job/AsyncSave.php
@@ -97,8 +97,6 @@ class AsyncSave extends AbstractQueuedJob
 
         // Create a real HTTPRequest with a session so Form::getRequest() and
         // Controller::curr()->getRequest()->getSession() work during job processing.
-        // A NullHTTPRequest (the default on a freshly created controller) is skipped
-        // by Form::getRequest(), which causes BadMethodCallException when building forms.
         $urlParams = $this->controllerState['URLParams'] ?? [];
         $recordID = $urlParams['ID'] ?? ($this->submission['ID'] ?? 0);
         $request = new HTTPRequest('GET', '/admin/pages/edit/EditForm/' . $recordID);

--- a/src/Job/AsyncSave.php
+++ b/src/Job/AsyncSave.php
@@ -3,6 +3,7 @@
 namespace AndrewAndante\SilverStripe\AsyncPublisher\Job;
 
 use SilverStripe\Control\Controller;
+use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\Session;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\DataObject;
@@ -94,9 +95,16 @@ class AsyncSave extends AbstractQueuedJob
             $controller->asyncRestoreState($this->controllerState);
         }
 
-        // Set up an empty session on the request so CMS code that calls
-        // getRequest()->getSession() does not throw during job processing.
-        $controller->getRequest()->setSession(new Session([]));
+        // Create a real HTTPRequest with a session so Form::getRequest() and
+        // Controller::curr()->getRequest()->getSession() work during job processing.
+        // A NullHTTPRequest (the default on a freshly created controller) is skipped
+        // by Form::getRequest(), which causes BadMethodCallException when building forms.
+        $urlParams = $this->controllerState['URLParams'] ?? [];
+        $recordID = $urlParams['ID'] ?? ($this->submission['ID'] ?? 0);
+        $request = new HTTPRequest('GET', '/admin/pages/edit/EditForm/' . $recordID);
+        $request->setSession(new Session([]));
+        $request->setRouteParams($urlParams);
+        $controller->setRequest($request);
 
         // Push the controller onto the stack so Controller::curr() returns a valid
         // controller for CMS extensions that expect an active HTTP context (e.g.

--- a/tests/Functional/AsyncPublisherTest.php
+++ b/tests/Functional/AsyncPublisherTest.php
@@ -5,7 +5,9 @@ namespace AndrewAndante\SilverStripe\AsyncPublisher\Tests\Functional;
 use AndrewAndante\SilverStripe\AsyncPublisher\Extension\AsyncPublisherExtension;
 use AndrewAndante\SilverStripe\AsyncPublisher\Job\AsyncPublish;
 use AndrewAndante\SilverStripe\AsyncPublisher\Job\AsyncSave;
+use SilverStripe\CMS\Controllers\CMSMain;
 use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Control\Session;
 use SilverStripe\Dev\FunctionalTest;
 use SilverStripe\Versioned\Versioned;
 use Symbiote\QueuedJobs\DataObjects\QueuedJobDescriptor;
@@ -165,6 +167,124 @@ class AsyncPublisherTest extends FunctionalTest
         $rerefreshedPage = SiteTree::get()->byID($page->ID);
         $this->assertTrue($rerefreshedPage->isPublished());
         $this->assertEquals('PublishRecursiveContent', $rerefreshedPage->getField('Content'));
+    }
+
+    /**
+     * A new record (ID = 'new-1') must be written to DB synchronously before the job runs,
+     * so the job can find the record by a real integer ID.
+     */
+    public function testQueueSaveNewRecord(): void
+    {
+        $this->logInWithPermission();
+
+        CMSMain::config()->set('tree_class', SiteTree::class);
+
+        $controller = new CMSMain();
+        $controller->getRequest()->setSession(new Session(null));
+        $controller->getResponseNegotiator()->setFragmentOverride([]);
+        $controller->setURLParams(['Action' => 'EditForm', 'ID' => 'new-1']);
+
+        $form = $controller->getEditForm('new-1');
+
+        $data = [
+            'ID' => 'new-1',
+            'ClassName' => SiteTree::class,
+            'Title' => 'New Record Test',
+        ];
+
+        $controller->asyncSave($data, $form);
+
+        // The record must exist in DB with a real integer ID after asyncSave().
+        /** @var SiteTree|AsyncPublisherExtension $newPage */
+        $newPage = SiteTree::get()->filter(['Title' => 'New Record Test'])->first();
+        $this->assertNotNull($newPage, 'New record should exist in DB after asyncSave()');
+        $this->assertGreaterThan(0, $newPage->ID, 'New record should have a real integer ID');
+
+        // A pending AsyncSave job should exist for the new record.
+        $this->assertTrue($newPage->pendingAsyncJobsExist([AsyncSave::class]));
+        $this->assertFalse($newPage->pendingAsyncJobsExist([AsyncPublish::class]));
+
+        $signature = $newPage->generateSignature();
+
+        QueuedJobService::singleton()->runJob(
+            QueuedJobDescriptor::get()->filter(['Implementation' => AsyncSave::class])->first()->ID
+        );
+
+        $this->assertEquals(
+            1,
+            QueuedJobDescriptor::get()
+                ->filter([
+                    'Implementation' => AsyncSave::class,
+                    'JobStatus' => QueuedJob::STATUS_COMPLETE,
+                    'Signature' => $signature,
+                ])
+                ->count()
+        );
+
+        // After the job runs, the record in DB should have the submitted title.
+        $savedPage = SiteTree::get()->byID($newPage->ID);
+        $this->assertEquals('New Record Test', $savedPage->getField('Title'));
+
+        // Save only — must NOT be published.
+        $this->assertFalse($savedPage->isPublished());
+    }
+
+    /**
+     * A new record with publish flag set must be written synchronously and then published
+     * once the async job runs.
+     */
+    public function testQueuePublishNewRecord(): void
+    {
+        $this->logInWithPermission();
+
+        CMSMain::config()->set('tree_class', SiteTree::class);
+
+        $controller = new CMSMain();
+        $controller->getRequest()->setSession(new Session(null));
+        $controller->getResponseNegotiator()->setFragmentOverride([]);
+        $controller->setURLParams(['Action' => 'EditForm', 'ID' => 'new-1']);
+
+        $form = $controller->getEditForm('new-1');
+
+        $data = [
+            'ID' => 'new-1',
+            'ClassName' => SiteTree::class,
+            'Title' => 'New Record Publish Test',
+            'publish' => 1,
+        ];
+
+        $controller->asyncSave($data, $form);
+
+        // The record must exist in DB with a real integer ID after asyncSave().
+        /** @var SiteTree|AsyncPublisherExtension $newPage */
+        $newPage = SiteTree::get()->filter(['Title' => 'New Record Publish Test'])->first();
+        $this->assertNotNull($newPage, 'New record should exist in DB after asyncSave()');
+        $this->assertGreaterThan(0, $newPage->ID, 'New record should have a real integer ID');
+
+        // A pending AsyncSave job (which will also publish) should exist for the new record.
+        $this->assertTrue($newPage->pendingAsyncJobsExist([AsyncSave::class]));
+
+        $signature = $newPage->generateSignature();
+
+        QueuedJobService::singleton()->runJob(
+            QueuedJobDescriptor::get()->filter(['Implementation' => AsyncSave::class])->first()->ID
+        );
+
+        $this->assertEquals(
+            1,
+            QueuedJobDescriptor::get()
+                ->filter([
+                    'Implementation' => AsyncSave::class,
+                    'JobStatus' => QueuedJob::STATUS_COMPLETE,
+                    'Signature' => $signature,
+                ])
+                ->count()
+        );
+
+        // After the job runs, the record should be published.
+        $publishedPage = SiteTree::get()->byID($newPage->ID);
+        $this->assertEquals('New Record Publish Test', $publishedPage->getField('Title'));
+        $this->assertTrue($publishedPage->isPublished());
     }
 
 }

--- a/tests/Functional/AsyncPublisherTest.php
+++ b/tests/Functional/AsyncPublisherTest.php
@@ -207,7 +207,7 @@ class AsyncPublisherTest extends FunctionalTest
         $signature = $newPage->generateSignature();
 
         QueuedJobService::singleton()->runJob(
-            QueuedJobDescriptor::get()->filter(['Implementation' => AsyncSave::class])->first()->ID
+            QueuedJobDescriptor::get()->filter(['Implementation' => AsyncSave::class, 'Signature' => $signature])->first()->ID
         );
 
         $this->assertEquals(
@@ -220,6 +220,7 @@ class AsyncPublisherTest extends FunctionalTest
                 ])
                 ->count()
         );
+        $this->assertFalse($newPage->pendingAsyncJobsExist());
 
         // After the job runs, the record in DB should have the submitted title.
         $savedPage = SiteTree::get()->byID($newPage->ID);
@@ -267,7 +268,7 @@ class AsyncPublisherTest extends FunctionalTest
         $signature = $newPage->generateSignature();
 
         QueuedJobService::singleton()->runJob(
-            QueuedJobDescriptor::get()->filter(['Implementation' => AsyncSave::class])->first()->ID
+            QueuedJobDescriptor::get()->filter(['Implementation' => AsyncSave::class, 'Signature' => $signature])->first()->ID
         );
 
         $this->assertEquals(
@@ -280,6 +281,7 @@ class AsyncPublisherTest extends FunctionalTest
                 ])
                 ->count()
         );
+        $this->assertFalse($newPage->pendingAsyncJobsExist());
 
         // After the job runs, the record should be published.
         $publishedPage = SiteTree::get()->byID($newPage->ID);


### PR DESCRIPTION
 ### Problem
In SilverStripe CMS 6, `CMSMain::getEditForm()` has a **strict Form return type**. When a new page (never saved to the database) is queued for async save/publish, the `AsyncSave` job fails with a fatal `TypeError` because the job tries to restore the edit form for a record that has never been persisted — `getEditForm()` returns null.

Three additional issues were found when fixing the root cause:
  1. No logged-in member in the job context — `canView()` returns false on draft pages
  2. No active controller — `Controller::curr()` returns null, crashing CMS extensions
  3. No HTTP session — `Form::getRequest()->getSession()` throws BadMethodCallException

### Fix
- _AsyncCMSMain::asyncSave()_ — when the submitted record has never been written (ID === 0), write it synchronously first to get a real database ID, then update the submission data and controller URL params before queuing the job.
- _AsyncSave::process()_ — restore the member who queued the job, create a real HTTPRequest with session, and push the controller onto the stack so the full CMS context is available when the job runs.
- _AsyncPublish::process()_ — same member/controller/session setup for the direct-publish path.